### PR TITLE
Paper-Wood balance

### DIFF
--- a/SeaBlock/control.lua
+++ b/SeaBlock/control.lua
@@ -60,7 +60,7 @@ local function init()
   end
   global.unlocks = {
     ['angels-ore3-crushed'] = {'sb-startup1', 'landfill'},
-    ['algae-brown'] = {'sb-startup2', 'bio-wood-processing', 'bio-paper-1'},
+    ['cellulose-fiber'] = {'sb-startup2', 'bio-wood-processing'},
     ['basic-circuit-board'] = {'sb-startup3', 'sct-lab-t1'},
   }
   if game.technology_prototypes['sct-automation-science-pack'] then

--- a/SeaBlock/data-updates/algae.lua
+++ b/SeaBlock/data-updates/algae.lua
@@ -46,10 +46,6 @@ seablock.lib.set_recipe_category('solid-calcium-carbonate', 'advanced-crafting')
 -- Alien bacteria
 seablock.lib.set_recipe_category('alien-bacteria', 'bio-processing-3')
 
--- Make these craftable by hand
-seablock.lib.set_recipe_category('solid-alginic-acid', 'crafting')
-seablock.lib.set_recipe_category('wooden-board-paper', 'crafting')
-
 -- Fix handcrafting trying to use wrong crafting path
 seablock.lib.set_recipe_category('wooden-board', 'electronics-machine')
 bobmods.lib.recipe.enabled('wooden-board', false)

--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -165,19 +165,6 @@ if data.raw.technology['logistics-0'] then
   bobmods.lib.tech.replace_prerequisite('long-inserters-1', 'logistics', 'logistics-0')
 end
 
--- Adjust for handcrafting boards
-
--- Divide by 2
-seablock.lib.substingredient('solid-alginic-acid', 'algae-brown', nil, 5)
-seablock.lib.substresult('solid-alginic-acid', 'solid-alginic-acid', nil, 1)
-data.raw.recipe['solid-alginic-acid'].energy_required = 5
-
--- Divide by 5
-seablock.lib.substingredient('solid-wood-pulp', 'cellulose-fiber', nil, 4)
-seablock.lib.substingredient('solid-wood-pulp', 'solid-alginic-acid', nil, 1)
-seablock.lib.substresult('solid-wood-pulp', 'solid-wood-pulp', nil, 4)
-data.raw.recipe['solid-wood-pulp'].energy_required = 0.8
-
 -- Tidy up ore silo prerequisites
 if mods['angelsaddons-storage'] then
   bobmods.lib.tech.remove_prerequisite('ore-silos', 'angels-coal-processing')

--- a/SeaBlock/data-updates/startup.lua
+++ b/SeaBlock/data-updates/startup.lua
@@ -7,6 +7,7 @@
 
 -- Second stage:
 -- Algae farm     5                                               10*2
+-- Composter      2x2                                   4x2
 
 local knowningredients = {
   ['angels-electrolyser'] = {
@@ -37,6 +38,12 @@ local knowningredients = {
     {'basic-circuit-board', 5},
     {'iron-stick', 10},
     {'stone-brick', 25}
+  },
+  ['composter'] = {
+    {'basic-circuit-board', 2},
+    {'iron-gear-wheel', 4},
+    {'stone-brick', 20},
+    {'iron-plate', 20}
   },
   ['angels-flare-stack'] = {
     {'iron-plate', 5},
@@ -233,14 +240,3 @@ data.raw.technology['bio-wood-processing'].unit = {
   ingredients = {},
   time = 5
 }
-
--- Make bio-paper-1 a startup tutorial tech
-data.raw.technology['bio-paper-1'].prerequisites = {'sb-startup2'}
-data.raw.technology['bio-paper-1'].unit = {
-  count = 1,
-  ingredients = {},
-  time = 5
-}
-bobmods.lib.tech.remove_recipe_unlock('bio-processing-brown', 'solid-alginic-acid')
-bobmods.lib.tech.add_recipe_unlock('bio-paper-1', 'solid-alginic-acid')
-bobmods.lib.tech.remove_prerequisite('bio-paper-2', 'bio-paper-1')

--- a/SeaBlock/data-updates/wood.lua
+++ b/SeaBlock/data-updates/wood.lua
@@ -1,12 +1,19 @@
--- No wood for electric poles, use wood bricks instead
-seablock.lib.substingredient('small-electric-pole', 'wood', 'wood-bricks', nil)
-
--- Wood removal
-seablock.lib.substingredient('phenolic-board', 'wood', 'wooden-board', 2)
+-- Replace wood with paper for T2 boards
+seablock.lib.substingredient('phenolic-board', 'wood', 'solid-paper', 4)
 
 -- Remove wood from basic underground belt and splitter recipes
 seablock.lib.removeingredient('basic-underground-belt', 'wood')
 seablock.lib.removeingredient('basic-splitter', 'wood')
+
+-- Remove 'wooden board from paper' recipe
+bobmods.lib.tech.remove_recipe_unlock('bio-paper-1', 'wooden-board-paper')
+seablock.lib.remove_recipe('wooden-board-paper')
+
+-- Allow hand-crafting for wooden boards
+seablock.lib.set_recipe_category('wooden-board', 'electronics')
+
+-- Move compost building recipe from bio-farm-1 to sb-startup-1
+seablock.lib.moveeffect('composter', 'bio-farm-1', 'sb-startup1', 4)
 
 -- Can always apply productivity modules to furnace recipes, so make it official
 for k,v in pairs(data.raw.module) do
@@ -20,16 +27,20 @@ bobmods.lib.tech.remove_recipe_unlock('bio-wood-processing', 'bio-resin-wood-rep
 bobmods.lib.tech.remove_recipe_unlock('bio-wood-processing-2', 'carbon-from-charcoal')
 bobmods.lib.tech.remove_recipe_unlock('bio-wood-processing-2', 'wood-charcoal')
 
-bobmods.lib.tech.replace_prerequisite('bio-wood-processing-3', 'angels-coal-processing-3', 'bio-arboretum-1')
-bobmods.lib.tech.replace_prerequisite('bio-wood-processing-3', 'angels-coal-processing-3', 'bio-arboretum-1')
+bobmods.lib.tech.remove_prerequisite('bio-wood-processing-3', 'logistic-science-pack')
+bobmods.lib.tech.remove_prerequisite('bio-wood-processing-3', 'bio-arboretum-1')
+bobmods.lib.tech.remove_prerequisite('bio-wood-processing-3', 'bio-wood-processing-2')
+bobmods.lib.tech.remove_recipe_unlock('bio-wood-processing-3', 'wooden-board')
+seablock.lib.hide_technology('bio-wood-processing-3')
 
 bobmods.lib.tech.remove_prerequisite('bio-arboretum-1', 'bio-wood-processing')
 
 -- Remove wooden chest from composter recipe
 bobmods.lib.recipe.remove_ingredient('composter', 'wooden-chest')
 
+bobmods.lib.tech.add_prerequisite('advanced-electronics', 'bio-paper-1')
 
-seablock.lib.moveeffect('cellulose-fiber-algae', 'bio-processing-brown', 'bio-wood-processing', 1)
+seablock.lib.moveeffect('cellulose-fiber-algae', 'bio-processing-brown', 'sb-startup1')
 seablock.lib.add_recipe_unlock('bio-wood-processing', 'cellulose-fiber-raw-wood', 2)
 bobmods.lib.recipe.enabled('cellulose-fiber-raw-wood', false)
 seablock.lib.add_recipe_unlock('bio-wood-processing', 'wood-pellets', 3)

--- a/SeaBlock/data/tables.lua
+++ b/SeaBlock/data/tables.lua
@@ -5,7 +5,6 @@ seablock.scripted_techs = {
   ['sb-startup1'] = true,
   ['landfill'] = true,
   ['sb-startup2'] = true,
-  ['bio-paper-1'] = true,
   ['bio-wood-processing'] = true,
   ['sb-startup3'] = true,
   ['sb-startup4'] = true

--- a/SeaBlock/locale/en/SeaBlock.cfg
+++ b/SeaBlock/locale/en/SeaBlock.cfg
@@ -1,7 +1,7 @@
 [recipe-name]
 sb-water-mineralized-crystallization=Mineralized water crystallization
-sb-cellulose-foraging=Forage for cellulose fiber
 sb-blue-algae-liquefaction=Blue algae liquefaction
+sb-wood-foraging=Forage for wood
 
 [item-name]
 charcoal=Charcoal
@@ -15,7 +15,7 @@ sb-ore-sorting-facility-5=Ore sorting facility 5
 
 [technology-name]
 sb-startup1=Crush stiratite
-sb-startup2=Farm brown algae
+sb-startup2=Produce cellulose fiber
 sb-startup3=Basic circuit board
 sb-startup4=Laboratory
 alloy-processing=Bronze processing
@@ -26,13 +26,13 @@ sb-bio-processing-advanced=Advanced algae processing
 
 [technology-description]
 sb-startup1=Crushed saphirite can be smelted to iron plates. Crushed stiratite can be smelted to copper plates.
-sb-startup2=Grow brown algae in an algae farm. Brown algae can be crafted into alginic acid which is needed to make wooden boards.
+sb-startup2=Grow green algae in an algae farm and convert it into cellulose fiber. Cellulose fiber can be used as fuel directly or processed for better efficiency.
 sb-startup3=Craft a basic circuit board. Basic circuit boards are required to craft most machines.
 alloy-processing=
 
 [item-description]
 sb-angelsore3-tool=Collect crushed stiratite ore from a burner ore crusher to complete this research
-sb-algae-brown-tool=Collect brown algae from an algae farm to complete this research
+sb-cellulose-tool=Produce cellulose fiber from green algae to complete this research
 sb-basic-circuit-board-tool=Craft one basic circuit board to complete this research
 sb-lab-tool=Craft a lab to complete this research
 

--- a/SeaBlock/prototypes/recipe.lua
+++ b/SeaBlock/prototypes/recipe.lua
@@ -59,17 +59,17 @@ data:extend({
   },
   {
     type = "recipe",
-    name = "sb-cellulose-foraging",
-    localised_name = {"recipe-name.sb-cellulose-foraging"},
+    name = "sb-wood-foraging",
+    localised_name = {"recipe-name.sb-wood-foraging"},
     category = "crafting-handonly",
     subgroup = "bio-processing-green",
     enabled = true,
-    energy_required = 2,
+    energy_required = 4,
     ingredients = {},
     results = {
-      {type = "item", name = "cellulose-fiber", amount = 1}
+      {type = "item", name = "wood", amount = 1}
     },
-    order = "ab[sb-cellulose-foraging]",
+    order = "ab[sb-wood-foraging]",
     allow_as_intermediate = true,
     allow_decomposition = false
   },

--- a/SeaBlock/prototypes/technology.lua
+++ b/SeaBlock/prototypes/technology.lua
@@ -21,9 +21,9 @@ data:extend({
 },
 {
   type = "tool",
-  name = "sb-algae-brown-tool",
-  localised_name = {"item-name.algae-brown"},
-  icon = "__angelsbioprocessing__/graphics/icons/algae-brown.png",
+  name = "sb-cellulose-tool",
+  localised_name = {"item-name.cellulose-fiber"},
+  icon = "__angelsbioprocessing__/graphics/icons/cellulose-fiber.png",
   icon_size = 32,
   flags = {"hidden"},
   stack_size = 100,
@@ -63,13 +63,14 @@ data:extend({
   icon = "__angelsbioprocessing__/graphics/technology/algae-farm-tech.png",
   icon_size = 128,
   effects = {
+    {type = "unlock-recipe", recipe = "wooden-board"},
     {type = "unlock-recipe", recipe = "basic-circuit-board"},
     {type = "unlock-recipe", recipe = "copper-cable"}
   },
   prerequisites = {"landfill"},
   unit = {
     count = 1,
-    ingredients = {{"sb-algae-brown-tool", 1}},
+    ingredients = {{"sb-cellulose-tool", 1}},
     time = 5
   }
 },
@@ -89,7 +90,7 @@ data:extend({
     {type = "unlock-recipe", recipe = "burner-inserter"},
     {type = "unlock-recipe", recipe = "iron-chest"}
   },
-  prerequisites = {"bio-wood-processing", "bio-paper-1"},
+  prerequisites = {"bio-wood-processing"},
   unit = {
     count = 1,
     ingredients = {{"sb-basic-circuit-board-tool", 1}},

--- a/SeaBlock/starting-items.lua
+++ b/SeaBlock/starting-items.lua
@@ -12,7 +12,7 @@ function seablock.populate_starting_items(items)
     ['stone-brick'] = 500,
     ['pipe'] = 22,
     ['copper-pipe'] = 5,
-    ['iron-gear-wheel'] = 20,
+    ['iron-gear-wheel'] = 28,
     ['iron-stick'] = 108,
     ['pipe-to-ground'] = 2
   }


### PR DESCRIPTION
**My take on issue #213 (partial - focusing on wood/paper balance):**
1. Wooden boards are now produced solely from wood; Phenolic boards are made with paper instead of wooden boards
2. Paper is now a red science (instead of startup tech) as in base B&A
3. Wood is available in the beginning through foraging (instead of foraging for cellulose fiber you forage for wood)
4. startup tech 1 now grants composter (ingredients changed to allow for 2 composters to be crafted while ensuring no soft-lock). This enables voiding of brown algae of T1 green algae recipe.
4. startup tech 2 (algae farm) now focused around fuel production (requires production of cellulose fiber instead of green algae)
5. paper 1 recipes returned to original speeds
6. Wood 3 tech removed (it only had wood -> wooden board recipe, which was moved to startup tech 2)

**Results:**
- paper is now necessary for T3 (red) circuits.
- wood is available at the start via foraging (by hand), and is used primarily for fuel or T1/2 (brown/green) circuits. By the time you need more brown circuits, you should ideally have researched wood production (red science), so hand crafting until then should be fine (similar to original B&A where wood is required and is hand-mined until wood farms)