### PR TITLE
Added Landblock setting, No Ores Setting, and No Trees/Rock Setting

### DIFF
--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -38,6 +38,9 @@ if settings.startup["Landblock-mode-Seablock-setting"].value == false then
   end
 end
 
+--if settings.startup["Landblock-mode-Seablock-setting"].value == true then
+
+--else
 
 local keepcontrols = {}
 local turrets = data.raw["turret"]
@@ -48,12 +51,15 @@ end
 end
 
 if settings.startup["Landblock-mode-Seablock-setting"].value == true then
-local enemies = data.raw["unit-spawner"]
-for enemies_name, turret in pairs(enemies) do
+local enem = data.raw["unit-spawner"]
+for enemies_name, turret in pairs(enem) do
 if turret.autoplace and turret.autoplace.control then
   keepcontrols[turret.autoplace.control] = true
 end
 end
+
+keepcontrols["angels-biter-slider"] = true
+
 end
 
 if settings.startup["No-minerals-mode-setting"].value == false then

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -1,3 +1,4 @@
+--header
 if settings.startup["No-minerals-mode-setting"].value == true then
 	-- No resource placement
 	for k, v in pairs(data.raw.resource) do
@@ -28,28 +29,60 @@ if settings.startup["No-trees-mode-setting"].value == true then
 	  seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
 	end
 end
+
 if settings.startup["Landblock-mode-Seablock-setting"].value == false then
   -- No spawners
   for k, v in pairs(data.raw["unit-spawner"]) do
     v.autoplace = nil
     v.control = nil
   end
-  
-  local keepcontrols = {}
-  local turrets = data.raw["turret"]
-  for turret_name, turret in pairs(turrets) do
-    if turret.autoplace and turret.autoplace.control then
-      keepcontrols[turret.autoplace.control] = true
-    end
-  end
-  
-  local controls = data.raw["autoplace-control"]
-  for k, v in pairs(controls) do
-    if k ~= "enemy-base" and not keepcontrols[k] then
-      controls[k] = nil
-    end
+end
+
+
+local keepcontrols = {}
+local turrets = data.raw["turret"]
+for turret_name, turret in pairs(turrets) do
+if turret.autoplace and turret.autoplace.control then
+  keepcontrols[turret.autoplace.control] = true
+end
+end
+
+if settings.startup["Landblock-mode-Seablock-setting"].value == true then
+local enemies = data.raw["unit-spawner"]
+for enemies_name, turret in pairs(enemies) do
+if turret.autoplace and turret.autoplace.control then
+  keepcontrols[turret.autoplace.control] = true
+end
+end
+end
+
+if settings.startup["No-minerals-mode-setting"].value == false then
+local resources = data.raw["resource"]
+for resource_name, turret in pairs(resources) do
+  if turret.autoplace and turret.autoplace.control then
+	keepcontrols[turret.autoplace.control] = true
   end
 end
+end
+
+if settings.startup["No-trees-mode-setting"].value == false then
+local trees = data.raw["tree"]
+for tree_name, turret in pairs(trees) do
+  if turret.autoplace and turret.autoplace.control then
+	keepcontrols[turret.autoplace.control] = true
+  end
+end
+end
+
+local controls = data.raw["autoplace-control"]
+--if settings.startup["No-minerals-mode-setting"].value == true then
+--if settings.startup["No-trees-mode-setting"].value == true then
+for k, v in pairs(controls) do
+  if k ~= "enemy-base" and not keepcontrols[k] then
+	controls[k] = nil
+  end
+end
+
 
 local presets = data.raw["map-gen-presets"]["default"]
 for k, v in pairs(presets) do

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -78,6 +78,14 @@ for tree_name, turret in pairs(trees) do
 	keepcontrols[turret.autoplace.control] = true
   end
 end
+
+local trees = data.raw["simple-entity"]
+for tree_name, turret in pairs(trees) do
+  if turret.autoplace and turret.autoplace.control then
+	keepcontrols[turret.autoplace.control] = true
+  end
+end
+
 end
 
 local controls = data.raw["autoplace-control"]

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -3,12 +3,6 @@ for k, v in pairs(data.raw.resource) do
   v.autoplace = nil
 end
 
--- No spawners
-for k, v in pairs(data.raw["unit-spawner"]) do
-  v.autoplace = nil
-  v.control = nil
-end
-
 -- No trees
 for k, v in pairs(data.raw.tree) do
   if
@@ -31,18 +25,26 @@ for k, v in pairs(data.raw["simple-entity"]) do
   seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
 end
 
-local keepcontrols = {}
-local turrets = data.raw["turret"]
-for turret_name, turret in pairs(turrets) do
-  if turret.autoplace and turret.autoplace.control then
-    keepcontrols[turret.autoplace.control] = true
+if settings.startup["Landblock-mode-Seablock"] == false then
+  -- No spawners
+  for k, v in pairs(data.raw["unit-spawner"]) do
+    v.autoplace = nil
+    v.control = nil
   end
-end
-
-local controls = data.raw["autoplace-control"]
-for k, v in pairs(controls) do
-  if k ~= "enemy-base" and not keepcontrols[k] then
-    controls[k] = nil
+  
+  local keepcontrols = {}
+  local turrets = data.raw["turret"]
+  for turret_name, turret in pairs(turrets) do
+    if turret.autoplace and turret.autoplace.control then
+      keepcontrols[turret.autoplace.control] = true
+    end
+  end
+  
+  local controls = data.raw["autoplace-control"]
+  for k, v in pairs(controls) do
+    if k ~= "enemy-base" and not keepcontrols[k] then
+      controls[k] = nil
+    end
   end
 end
 

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -1,31 +1,33 @@
+if settings.startup["No-minerals-mode-setting"].value == true then
 -- No resource placement
 for k, v in pairs(data.raw.resource) do
   v.autoplace = nil
 end
 
--- No trees
-for k, v in pairs(data.raw.tree) do
-  if
-    k ~= "temperate-garden"
-    and k ~= "desert-garden"
-    and k ~= "swamp-garden"
-    and k ~= "temperate-tree"
-    and k ~= "desert-tree"
-    and k ~= "swamp-tree"
-    and k ~= "puffer-nest"
-  then
-    v.autoplace = nil
-    seablock.lib.add_flag("tree", v.name, "not-deconstructable")
-  end
-end
+if settings.startup["No-trees-mode-setting"].value == true then
+	-- No trees
+	for k, v in pairs(data.raw.tree) do
+	  if
+		k ~= "temperate-garden"
+		and k ~= "desert-garden"
+		and k ~= "swamp-garden"
+		and k ~= "temperate-tree"
+		and k ~= "desert-tree"
+		and k ~= "swamp-tree"
+		and k ~= "puffer-nest"
+	  then
+		v.autoplace = nil
+		seablock.lib.add_flag("tree", v.name, "not-deconstructable")
+	  end
+	end
 
--- No rocks
-for k, v in pairs(data.raw["simple-entity"]) do
-  v.autoplace = nil
-  seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
+	-- No rocks
+	for k, v in pairs(data.raw["simple-entity"]) do
+	  v.autoplace = nil
+	  seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
+	end
 end
-
-if settings.startup["Landblock-mode-Seablock-setting"] == false then
+if settings.startup["Landblock-mode-Seablock-setting"].value == false then
   -- No spawners
   for k, v in pairs(data.raw["unit-spawner"]) do
     v.autoplace = nil

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -1,7 +1,8 @@
 if settings.startup["No-minerals-mode-setting"].value == true then
--- No resource placement
-for k, v in pairs(data.raw.resource) do
-  v.autoplace = nil
+	-- No resource placement
+	for k, v in pairs(data.raw.resource) do
+		v.autoplace = nil
+	end
 end
 
 if settings.startup["No-trees-mode-setting"].value == true then

--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -25,7 +25,7 @@ for k, v in pairs(data.raw["simple-entity"]) do
   seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
 end
 
-if settings.startup["Landblock-mode-Seablock"] == false then
+if settings.startup["Landblock-mode-Seablock-setting"] == false then
   -- No spawners
   for k, v in pairs(data.raw["unit-spawner"]) do
     v.autoplace = nil

--- a/SeaBlock/data-final-fixes/unobtainable_items.lua
+++ b/SeaBlock/data-final-fixes/unobtainable_items.lua
@@ -106,7 +106,7 @@ for _, v in ipairs({
   "bio-tile",
   "burner-generator",
   "burner-mining-drill",
-  "coal",
+--"coal",
   "coal-crushed",
   "diesel-fuel",
   "diesel-fuel-barrel",
@@ -124,6 +124,9 @@ for _, v in ipairs({
   "pumpjack",
 }) do
   unobtainable[v] = {}
+end
+if settings.startup["No-minerals-mode-setting"].value == true then
+	unobtainable["coal"] = {}
 end
 
 -- unobtainable[key] -> { { a, and b, and .. }, or { c, ... } or, { d, and e, and f, ...}... }

--- a/SeaBlock/data-updates/coal.lua
+++ b/SeaBlock/data-updates/coal.lua
@@ -24,9 +24,11 @@ seablock.lib.moveeffect("pellet-coke", "angels-coal-cracking", "angels-coal-proc
 data.raw.item["carbon"].fuel_emissions_multiplier = nil
 data.raw.item["carbon"].fuel_value = nil
 data.raw.item["carbon"].fuel_category = nil
-data.raw.item["coal"].fuel_emissions_multiplier = nil
-data.raw.item["coal"].fuel_value = nil
-data.raw.item["coal"].fuel_category = nil
+if settings.startup["No-minerals-mode-setting"].value == true then
+  data.raw.item["coal"].fuel_emissions_multiplier = nil
+  data.raw.item["coal"].fuel_value = nil
+  data.raw.item["coal"].fuel_category = nil
+end
 data.raw.item["coal-crushed"].fuel_value = nil
 data.raw.item["coal-crushed"].fuel_category = nil
 

--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -63,12 +63,14 @@ end
 
 -- Remove resources so mining recipes don't show in FNEI
 -- Have to leave at least one resource or game will not load
-for k, v in pairs(data.raw["resource"]) do
-  if k == "coal" then
-    v.minable.result = nil
-    v.minable.results = nil
-  else
-    data.raw["resource"][k] = nil
+if settings.startup["No-minerals-mode-setting"].value == true then
+  for k, v in pairs(data.raw["resource"]) do
+    if k == "coal" then
+      v.minable.result = nil
+      v.minable.results = nil
+    else
+      data.raw["resource"][k] = nil
+    end
   end
 end
 

--- a/SeaBlock/locale/en/SeaBlock.cfg
+++ b/SeaBlock/locale/en/SeaBlock.cfg
@@ -61,6 +61,7 @@ sb-lab-tool=Craft a lab to complete this research
 [mod-setting-name]
 sb-default-landfill=Default landfill type
 bobmods-assembly-multipurposefurnaces=Recipe furnaces
+Landblock-mode-Seablock-setting=Landblock mode (Keeps Recipes the same changes mapgen to normal-ish)
 
 [string-mod-setting]
 sb-default-landfill-landfill-dirt-4=[img=item/landfill-dirt-4]Dirt

--- a/SeaBlock/locale/en/SeaBlock.cfg
+++ b/SeaBlock/locale/en/SeaBlock.cfg
@@ -61,7 +61,9 @@ sb-lab-tool=Craft a lab to complete this research
 [mod-setting-name]
 sb-default-landfill=Default landfill type
 bobmods-assembly-multipurposefurnaces=Recipe furnaces
-Landblock-mode-Seablock-setting=Landblock mode (Keeps Recipes the same changes mapgen to normal-ish)
+Landblock-mode-Seablock-setting=Landblock mode (Keeps Recipes the same changes mapgen to normal-ish) (Default=unchecked)
+No-minerals-mode-setting=Setting to turn on normal resource production for mod incompatabilities (Default=checked)
+No-trees-mode-setting=Setting to turn on normal tree/rock growth for mod incompatabilities (Default=checked)
 
 [string-mod-setting]
 sb-default-landfill-landfill-dirt-4=[img=item/landfill-dirt-4]Dirt

--- a/SeaBlock/mapgen.lua
+++ b/SeaBlock/mapgen.lua
@@ -31,9 +31,17 @@ data.raw.tile["sand-5"].vehicle_friction_modifier = 1.8
 
 data.raw.tile["landfill"].vehicle_friction_modifier = 1.8
 
-if settings.startup["Landblock-mode-Seablock-setting"].value == false then
 
-	for _, v in pairs(data.raw.tile) do
+local octaves = -3
+local persistence = 0.2
+local waterline = 9.4
+local elevation_scale = 5
+local function scale_elevation(x)
+  return (x - waterline) * elevation_scale + waterline
+end
+
+if settings.startup["Landblock-mode-Seablock-setting"].value == false then
+	for k, v in pairs(data.raw.tile) do
 	  v.autoplace = nil
 	end
 
@@ -44,13 +52,6 @@ if settings.startup["Landblock-mode-Seablock-setting"].value == false then
 	-- So use train-layer as a substitute player-layer
 	data.raw.cliff["cliff"].collision_mask = { "object-layer", "train-layer", "not-colliding-with-itself" }
 
-	local octaves = -3
-	local persistence = 0.2
-	local waterline = 9.4
-	local elevation_scale = 5
-	local function scale_elevation(x)
-	  return (x - waterline) * elevation_scale + waterline
-	end
 	-- low lying sand
 	data.raw.tile["sand-4"].autoplace = {
 	  peaks = {
@@ -130,160 +131,7 @@ if settings.startup["Landblock-mode-Seablock-setting"].value == false then
 		},
 	  },
 	}
-
-	local plant_elevation_range = 9.9 * elevation_scale
-	data.raw.tree["desert-garden"].autoplace = {
-	  max_probability = 0.2,
-	  random_probability_penalty = 0.05,
-	  sharpness = 1,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-		{
-		  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
-		  min_influence = 0,
-		  max_influence = 1,
-		  noise_layer = "enemy-base",
-		  noise_octaves_difference = octaves,
-		  noise_persistence = persistence,
-		  tier_from_start_optimal = 0,
-		  tier_from_start_range = 0.1,
-		  tier_from_start_max_range = 0.1,
-		},
-		{
-		  influence = 1,
-		  max_influence = 0,
-		  noise_layer = "desert-garden-noise",
-		  noise_persistence = 0.8,
-		  noise_octaves_difference = -0.5,
-		},
-	  },
-	  order = "yc",
-	  tile_restriction = { "sand-5" },
-	}
-
-	data.raw.tree["temperate-garden"].autoplace = {
-	  max_probability = 0.2,
-	  random_probability_penalty = 0.05,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-		{
-		  influence = 1,
-		  max_influence = 0,
-		  noise_layer = "temperate-garden-noise",
-		  noise_persistence = 0.8,
-		  noise_octaves_difference = -0.5,
-		},
-	  },
-	  order = "ya",
-	  tile_restriction = { "sand-5" },
-	}
-
-	data.raw.tree["swamp-garden"].autoplace = {
-	  max_probability = 0.05,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-	  },
-	  order = "yb",
-	  tile_restriction = { "sand-5" },
-	}
-
-	data.raw.tree["desert-tree"].autoplace = {
-	  max_probability = 0.1,
-	  random_probability_penalty = 0.025,
-	  sharpness = 1,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-		{
-		  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
-		  min_influence = 0,
-		  max_influence = 1,
-		  noise_layer = "enemy-base",
-		  noise_octaves_difference = octaves,
-		  noise_persistence = persistence,
-		  tier_from_start_optimal = 0,
-		  tier_from_start_range = 0.1,
-		  tier_from_start_max_range = 0.1,
-		},
-		{
-		  influence = 1,
-		  max_influence = 0,
-		  noise_layer = "desert-tree-noise",
-		  noise_persistence = 0.8,
-		  noise_octaves_difference = -0.5,
-		},
-	  },
-	  order = "za",
-	  tile_restriction = { "sand-5" },
-	}
-	data.raw.tree["temperate-tree"].autoplace = {
-	  max_probability = 0.1,
-	  random_probability_penalty = 0.025,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-		{
-		  influence = 1,
-		  max_influence = 0,
-		  noise_layer = "temperate-tree-noise",
-		  noise_persistence = 0.8,
-		  noise_octaves_difference = -0.5,
-		},
-	  },
-	  order = "zc",
-	  tile_restriction = { "sand-5" },
-	}
-
-	data.raw.tree["swamp-tree"].autoplace = {
-	  max_probability = 0.05,
-	  peaks = {
-		{
-		  influence = 1,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(20),
-		  elevation_range = plant_elevation_range,
-		  elevation_max_range = plant_elevation_range,
-		},
-		{
-		  influence = 1,
-		  max_influence = 0,
-		  noise_layer = "swamp-tree-noise",
-		  noise_persistence = 0.8,
-		  noise_octaves_difference = -0.5,
-		},
-	  },
-	  order = "zb",
-	  tile_restriction = { "sand-5" },
-	}
-
+	
 	data.raw.tile["water"].autoplace = {
 	  peaks = {
 		{
@@ -319,165 +167,327 @@ if settings.startup["Landblock-mode-Seablock-setting"].value == false then
 	  },
 	}
 
-	data.raw.fish["alien-fish-1"].autoplace = {
-	  peaks = {
-		{
-		  influence = -0.1,
-		  max_influence = 0,
-		  noise_layer = "enemy-base",
-		  noise_octaves_difference = octaves,
-		  noise_persistence = persistence,
-		},
-		{
-		  influence = 0.01,
-		},
-	  },
-	}
 
-	data.raw.fish["alien-fish-2"].autoplace = {
-	  peaks = {
-		{
-		  influence = 0.02,
-		  min_influence = 0,
-		  noise_layer = "enemy-base",
-		  noise_octaves_difference = octaves,
-		  noise_persistence = persistence,
-		},
-	  },
-	}
+local plant_elevation_range = 9.9 * elevation_scale
+data.raw.tree["desert-garden"].autoplace = {
+  max_probability = 0.2,
+  random_probability_penalty = 0.05,
+  sharpness = 1,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+	{
+	  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
+	  min_influence = 0,
+	  max_influence = 1,
+	  noise_layer = "enemy-base",
+	  noise_octaves_difference = octaves,
+	  noise_persistence = persistence,
+	  tier_from_start_optimal = 0,
+	  tier_from_start_range = 0.1,
+	  tier_from_start_max_range = 0.1,
+	},
+	{
+	  influence = 1,
+	  max_influence = 0,
+	  noise_layer = "desert-garden-noise",
+	  noise_persistence = 0.8,
+	  noise_octaves_difference = -0.5,
+	},
+  },
+  order = "yc",
+  tile_restriction = { "sand-5" },
+}
 
-	data.raw.fish["alien-fish-3"].autoplace = {
-	  peaks = {
-		{
-		  influence = 0.015,
-		  min_influence = 0,
-		  elevation_optimal = scale_elevation(10),
-		  elevation_range = 5 * elevation_scale,
-		  elevation_max_range = 5 * elevation_scale,
-		  tier_from_start_optimal = 0.1,
-		  tier_from_start_range = 0,
-		  tier_from_start_max_range = 0,
-		  tier_from_start_top_property_limit = 0.1,
-		},
-	  },
-	}
+data.raw.tree["temperate-garden"].autoplace = {
+  max_probability = 0.2,
+  random_probability_penalty = 0.05,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+	{
+	  influence = 1,
+	  max_influence = 0,
+	  noise_layer = "temperate-garden-noise",
+	  noise_persistence = 0.8,
+	  noise_octaves_difference = -0.5,
+	},
+  },
+  order = "ya",
+  tile_restriction = { "sand-5" },
+}
 
-	local noise = require("noise")
-	local tne = noise.to_noise_expression
-	local enemy_random_seed = 1
-	local function new_random_seed()
-	  enemy_random_seed = enemy_random_seed + 1
-	  return enemy_random_seed
-	end
-	local function worm_autoplace(distance, probability, order, falloff, control_name)
-	  local d = noise.var("distance") - noise.var("starting_area_radius")
-	  local p = noise.clamp((d - distance * 128) / 128, 0, 1)
-	  if falloff then
-		p = p * noise.clamp(((distance + 2) * 128 - d) / 128, 0, 1)
-	  end
-	  p = p * noise.clamp((waterline - noise.var("elevation")), 0, 1)
-	  p = p * probability
-	  p = noise.random_penalty(p, probability * 0.5, {
-		x = noise.var("x") + new_random_seed(),
-	  })
+data.raw.tree["swamp-garden"].autoplace = {
+  max_probability = 0.05,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+  },
+  order = "yb",
+  tile_restriction = { "sand-5" },
+}
 
-	  return {
-		control = control_name,
-		order = order,
-		force = "enemy",
-		probability_expression = p,
-		richness_expression = tne(1),
-	  }
-	end
+data.raw.tree["desert-tree"].autoplace = {
+  max_probability = 0.1,
+  random_probability_penalty = 0.025,
+  sharpness = 1,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+	{
+	  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
+	  min_influence = 0,
+	  max_influence = 1,
+	  noise_layer = "enemy-base",
+	  noise_octaves_difference = octaves,
+	  noise_persistence = persistence,
+	  tier_from_start_optimal = 0,
+	  tier_from_start_range = 0.1,
+	  tier_from_start_max_range = 0.1,
+	},
+	{
+	  influence = 1,
+	  max_influence = 0,
+	  noise_layer = "desert-tree-noise",
+	  noise_persistence = 0.8,
+	  noise_octaves_difference = -0.5,
+	},
+  },
+  order = "za",
+  tile_restriction = { "sand-5" },
+}
+data.raw.tree["temperate-tree"].autoplace = {
+  max_probability = 0.1,
+  random_probability_penalty = 0.025,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+	{
+	  influence = 1,
+	  max_influence = 0,
+	  noise_layer = "temperate-tree-noise",
+	  noise_persistence = 0.8,
+	  noise_octaves_difference = -0.5,
+	},
+  },
+  order = "zc",
+  tile_restriction = { "sand-5" },
+}
 
-	data.raw.turret["small-worm-turret"].autoplace = worm_autoplace(0, 1, "z", true, "enemy-base")
-	data.raw.turret["medium-worm-turret"].autoplace = worm_autoplace(1, 1, "y", true, "enemy-base")
-	if data.raw.turret["bob-big-explosive-worm-turret"] then
-	  data.raw.turret["bob-big-explosive-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	end
-	if data.raw.turret["bob-big-fire-worm-turret"] then
-	  data.raw.turret["bob-big-fire-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	end
-	if data.raw.turret["bob-big-poison-worm-turret"] then
-	  data.raw.turret["bob-big-poison-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	end
-	if data.raw.turret["bob-big-piercing-worm-turret"] then
-	  data.raw.turret["bob-big-piercing-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	end
-	if data.raw.turret["bob-big-electric-worm-turret"] then
-	  data.raw.turret["bob-big-electric-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	end
-	if data.raw.turret["bob-giant-worm-turret"] then
-	  data.raw.turret["bob-giant-worm-turret"].autoplace = worm_autoplace(2, 0.6, "u", false, "enemy-base")
-	end
-	if data.raw.turret["behemoth-worm-turret"] then
-	  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-	  data.raw.turret["behemoth-worm-turret"].autoplace = worm_autoplace(2, 0.2, "t", false, "enemy-base")
-	else
-	  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(2, 1, "v", false, "enemy-base")
-	end
-	data.raw.tree["puffer-nest"].autoplace = worm_autoplace(0, 0.01, "s", false)
+data.raw.tree["swamp-tree"].autoplace = {
+  max_probability = 0.05,
+  peaks = {
+	{
+	  influence = 1,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(20),
+	  elevation_range = plant_elevation_range,
+	  elevation_max_range = plant_elevation_range,
+	},
+	{
+	  influence = 1,
+	  max_influence = 0,
+	  noise_layer = "swamp-tree-noise",
+	  noise_persistence = 0.8,
+	  noise_octaves_difference = -0.5,
+	},
+  },
+  order = "zb",
+  tile_restriction = { "sand-5" },
+}
 
-	for _, v in pairs(data.raw.turret) do
-	  v.map_generator_bounding_box = nil
-	end
+data.raw.fish["alien-fish-1"].autoplace = {
+  peaks = {
+	{
+	  influence = -0.1,
+	  max_influence = 0,
+	  noise_layer = "enemy-base",
+	  noise_octaves_difference = octaves,
+	  noise_persistence = persistence,
+	},
+	{
+	  influence = 0.01,
+	},
+  },
+}
 
-	data:extend({
-	  {
-		type = "noise-layer",
-		name = "desert-tree-noise",
-	  },
-	  {
-		type = "noise-layer",
-		name = "temperate-tree-noise",
-	  },
-	  {
-		type = "noise-layer",
-		name = "swamp-tree-noise",
-	  },
-	  {
-		type = "noise-layer",
-		name = "desert-garden-noise",
-	  },
-	  {
-		type = "noise-layer",
-		name = "temperate-garden-noise",
-	  },
-	  {
-		type = "noise-layer",
-		name = "swamp-garden-noise",
+data.raw.fish["alien-fish-2"].autoplace = {
+  peaks = {
+	{
+	  influence = 0.02,
+	  min_influence = 0,
+	  noise_layer = "enemy-base",
+	  noise_octaves_difference = octaves,
+	  noise_persistence = persistence,
+	},
+  },
+}
+
+data.raw.fish["alien-fish-3"].autoplace = {
+  peaks = {
+	{
+	  influence = 0.015,
+	  min_influence = 0,
+	  elevation_optimal = scale_elevation(10),
+	  elevation_range = 5 * elevation_scale,
+	  elevation_max_range = 5 * elevation_scale,
+	  tier_from_start_optimal = 0.1,
+	  tier_from_start_range = 0,
+	  tier_from_start_max_range = 0,
+	  tier_from_start_top_property_limit = 0.1,
+	},
+  },
+}
+
+local noise = require("noise")
+local tne = noise.to_noise_expression
+local enemy_random_seed = 1
+local function new_random_seed()
+  enemy_random_seed = enemy_random_seed + 1
+  return enemy_random_seed
+end
+local function worm_autoplace(distance, probability, order, falloff, control_name)
+  local d = noise.var("distance") - noise.var("starting_area_radius")
+  local p = noise.clamp((d - distance * 128) / 128, 0, 1)
+  if falloff then
+	p = p * noise.clamp(((distance + 2) * 128 - d) / 128, 0, 1)
+  end
+  p = p * noise.clamp((waterline - noise.var("elevation")), 0, 1)
+  p = p * probability
+  p = noise.random_penalty(p, probability * 0.5, {
+	x = noise.var("x") + new_random_seed(),
+  })
+
+  return {
+	control = control_name,
+	order = order,
+	force = "enemy",
+	probability_expression = p,
+	richness_expression = tne(1),
+  }
+end
+
+data.raw.turret["small-worm-turret"].autoplace = worm_autoplace(0, 1, "z", true, "enemy-base")
+data.raw.turret["medium-worm-turret"].autoplace = worm_autoplace(1, 1, "y", true, "enemy-base")
+if data.raw.turret["bob-big-explosive-worm-turret"] then
+  data.raw.turret["bob-big-explosive-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+end
+if data.raw.turret["bob-big-fire-worm-turret"] then
+  data.raw.turret["bob-big-fire-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+end
+if data.raw.turret["bob-big-poison-worm-turret"] then
+  data.raw.turret["bob-big-poison-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+end
+if data.raw.turret["bob-big-piercing-worm-turret"] then
+  data.raw.turret["bob-big-piercing-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+end
+if data.raw.turret["bob-big-electric-worm-turret"] then
+  data.raw.turret["bob-big-electric-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+end
+if data.raw.turret["bob-giant-worm-turret"] then
+  data.raw.turret["bob-giant-worm-turret"].autoplace = worm_autoplace(2, 0.6, "u", false, "enemy-base")
+end
+if data.raw.turret["behemoth-worm-turret"] then
+  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+  data.raw.turret["behemoth-worm-turret"].autoplace = worm_autoplace(2, 0.2, "t", false, "enemy-base")
+else
+  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(2, 1, "v", false, "enemy-base")
+end
+data.raw.tree["puffer-nest"].autoplace = worm_autoplace(0, 0.01, "s", false)
+
+for _, v in pairs(data.raw.turret) do
+  v.map_generator_bounding_box = nil
+end
+
+data:extend({
+  {
+	type = "noise-layer",
+	name = "desert-tree-noise",
+  },
+  {
+	type = "noise-layer",
+	name = "temperate-tree-noise",
+  },
+  {
+	type = "noise-layer",
+	name = "swamp-tree-noise",
+  },
+  {
+	type = "noise-layer",
+	name = "desert-garden-noise",
+  },
+  {
+	type = "noise-layer",
+	name = "temperate-garden-noise",
+  },
+  {
+	type = "noise-layer",
+	name = "swamp-garden-noise",
+  },
+})
+
+local function make_basis_noise_function(seed0, seed1, outscale0, inscale0)
+  outscale0 = outscale0 or 1
+  inscale0 = inscale0 or 1 / outscale0
+  return function(x, y, inscale, outscale)
+	return tne({
+	  type = "function-application",
+	  function_name = "factorio-basis-noise",
+	  arguments = {
+		x = tne(x),
+		y = tne(y),
+		seed0 = tne(seed0),
+		seed1 = tne(seed1),
+		input_scale = tne((inscale or 1) * inscale0),
+		output_scale = tne((outscale or 1) * outscale0),
 	  },
 	})
+  end
+end
 
-	local function make_basis_noise_function(seed0, seed1, outscale0, inscale0)
-	  outscale0 = outscale0 or 1
-	  inscale0 = inscale0 or 1 / outscale0
-	  return function(x, y, inscale, outscale)
-		return tne({
-		  type = "function-application",
-		  function_name = "factorio-basis-noise",
-		  arguments = {
-			x = tne(x),
-			y = tne(y),
-			seed0 = tne(seed0),
-			seed1 = tne(seed1),
-			input_scale = tne((inscale or 1) * inscale0),
-			output_scale = tne((outscale or 1) * outscale0),
-		  },
-		})
-	  end
+--if settings.startup["Landblock-mode-Seablock-setting"].value == false then
+  data.raw["noise-expression"]["cliffiness"].expression = noise.define_noise_function(function(x, y, tile, map)
+    local t = noise.clamp((tile.tier - 0.2) * noise.ceil(noise.var("control-setting:cliffs:richness:multiplier")), 0, 1) -- No cliffs in starting area
+      return 100 * t
+    end)
+  data.raw["noise-expression"]["elevation"].expression = noise.define_noise_function(function(x, y, tile, map)
+    x = x + 40000
+    y = y
+    local v = make_basis_noise_function(map.seed, 5, 6, 1 / 64)(x, y)
+    v = noise.max(v, 0)
+    v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
+    return v
+  end)
+
+
+  for k, v in pairs(data.raw.tree) do
+    if v.autoplace.tile_restriction ~= nil then
+	  v.autoplace.tile_restriction = nil
 	end
-
-	data.raw["noise-expression"]["cliffiness"].expression = noise.define_noise_function(function(x, y, tile, map)
-	  local t = noise.clamp((tile.tier - 0.2) * noise.ceil(noise.var("control-setting:cliffs:richness:multiplier")), 0, 1) -- No cliffs in starting area
-	  return 100 * t
-	end)
-	data.raw["noise-expression"]["elevation"].expression = noise.define_noise_function(function(x, y, tile, map)
-	  x = x + 40000
-	  y = y
-	  local v = make_basis_noise_function(map.seed, 5, 6, 1 / 64)(x, y)
-	  v = noise.max(v, 0)
-	  v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
-	  return v
-	end)
+  end
 end

--- a/SeaBlock/mapgen.lua
+++ b/SeaBlock/mapgen.lua
@@ -470,7 +470,7 @@ local function make_basis_noise_function(seed0, seed1, outscale0, inscale0)
   end
 end
 
---if settings.startup["Landblock-mode-Seablock-setting"].value == false then
+if settings.startup["Landblock-mode-Seablock-setting"].value == false then
   data.raw["noise-expression"]["cliffiness"].expression = noise.define_noise_function(function(x, y, tile, map)
     local t = noise.clamp((tile.tier - 0.2) * noise.ceil(noise.var("control-setting:cliffs:richness:multiplier")), 0, 1) -- No cliffs in starting area
       return 100 * t
@@ -483,7 +483,7 @@ end
     v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
     return v
   end)
-
+end
 
   for k, v in pairs(data.raw.tree) do
     if v.autoplace.tile_restriction ~= nil then

--- a/SeaBlock/mapgen.lua
+++ b/SeaBlock/mapgen.lua
@@ -31,7 +31,7 @@ data.raw.tile["sand-5"].vehicle_friction_modifier = 1.8
 
 data.raw.tile["landfill"].vehicle_friction_modifier = 1.8
 
-if settings.startup["Landblock-mode-Seablock-setting"] == false then
+if settings.startup["Landblock-mode-Seablock-setting"].value == false then
 
 	for _, v in pairs(data.raw.tile) do
 	  v.autoplace = nil

--- a/SeaBlock/mapgen.lua
+++ b/SeaBlock/mapgen.lua
@@ -31,450 +31,453 @@ data.raw.tile["sand-5"].vehicle_friction_modifier = 1.8
 
 data.raw.tile["landfill"].vehicle_friction_modifier = 1.8
 
-for _, v in pairs(data.raw.tile) do
-  v.autoplace = nil
+if settings.startup["Landblock-mode-Seablock-setting"] == false then
+
+	for _, v in pairs(data.raw.tile) do
+	  v.autoplace = nil
+	end
+
+	-- Want player to collide with cliffs
+	-- Want player to collide with water
+	-- Don't want cliffs to collide with water
+	-- Water tile's default collision mask includes player-layer and item-layer
+	-- So use train-layer as a substitute player-layer
+	data.raw.cliff["cliff"].collision_mask = { "object-layer", "train-layer", "not-colliding-with-itself" }
+
+	local octaves = -3
+	local persistence = 0.2
+	local waterline = 9.4
+	local elevation_scale = 5
+	local function scale_elevation(x)
+	  return (x - waterline) * elevation_scale + waterline
+	end
+	-- low lying sand
+	data.raw.tile["sand-4"].autoplace = {
+	  peaks = {
+		{ -- Around cliff islands
+		  influence = 5,
+		  elevation_optimal = 0.3 * elevation_scale + waterline,
+		  elevation_range = 0.3 * elevation_scale,
+		  elevation_max_range = 0.3 * elevation_scale,
+		},
+		{
+		  influence = 0.77 * 8, -- Worm islands
+		  min_influence = 0,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		  tier_from_start_optimal = 8,
+		  tier_from_start_max_range = 40,
+		  tier_from_start_top_property_limit = 8,
+		},
+		{ -- Not in starting area
+		  influence = -5,
+		  starting_area_weight_optimal = 1,
+		  starting_area_weight_range = 0,
+		  starting_area_weight_max_range = 0,
+		},
+		{
+		  influence = 100, -- ... except for starting tile
+		  min_influence = 0,
+		  distance_optimal = 0,
+		  distance_range = 0.1,
+		  distance_max_range = 0.1,
+		},
+		{
+		  influence = -5,
+		},
+	  },
+	}
+
+	-- highground sand
+	data.raw.tile["sand-5"].autoplace = {
+	  peaks = {
+		{
+		  influence = 5,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(15),
+		  elevation_range = 5 * elevation_scale,
+		  elevation_max_range = 5 * elevation_scale,
+		  tier_from_start_optimal = 0.1,
+		  tier_from_start_range = 0,
+		  tier_from_start_max_range = 0,
+		  tier_from_start_top_property_limit = 0.1,
+		},
+		{
+		  influence = 0.65, -- starting area garden islands
+		  min_influence = 0,
+		  max_influence = 1,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		  tier_from_start_optimal = 0,
+		  tier_from_start_range = 0.1,
+		  tier_from_start_max_range = 0.1,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  starting_area_weight_optimal = 1,
+		  starting_area_weight_range = 0,
+		  starting_area_weight_max_range = 0,
+		},
+		{
+		  influence = -100, -- not on starting tile
+		  max_influence = 0,
+		  distance_optimal = 0,
+		  distance_range = 3,
+		  distance_max_range = 3,
+		},
+	  },
+	}
+
+	local plant_elevation_range = 9.9 * elevation_scale
+	data.raw.tree["desert-garden"].autoplace = {
+	  max_probability = 0.2,
+	  random_probability_penalty = 0.05,
+	  sharpness = 1,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+		{
+		  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
+		  min_influence = 0,
+		  max_influence = 1,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		  tier_from_start_optimal = 0,
+		  tier_from_start_range = 0.1,
+		  tier_from_start_max_range = 0.1,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  noise_layer = "desert-garden-noise",
+		  noise_persistence = 0.8,
+		  noise_octaves_difference = -0.5,
+		},
+	  },
+	  order = "yc",
+	  tile_restriction = { "sand-5" },
+	}
+
+	data.raw.tree["temperate-garden"].autoplace = {
+	  max_probability = 0.2,
+	  random_probability_penalty = 0.05,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  noise_layer = "temperate-garden-noise",
+		  noise_persistence = 0.8,
+		  noise_octaves_difference = -0.5,
+		},
+	  },
+	  order = "ya",
+	  tile_restriction = { "sand-5" },
+	}
+
+	data.raw.tree["swamp-garden"].autoplace = {
+	  max_probability = 0.05,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+	  },
+	  order = "yb",
+	  tile_restriction = { "sand-5" },
+	}
+
+	data.raw.tree["desert-tree"].autoplace = {
+	  max_probability = 0.1,
+	  random_probability_penalty = 0.025,
+	  sharpness = 1,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+		{
+		  influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
+		  min_influence = 0,
+		  max_influence = 1,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		  tier_from_start_optimal = 0,
+		  tier_from_start_range = 0.1,
+		  tier_from_start_max_range = 0.1,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  noise_layer = "desert-tree-noise",
+		  noise_persistence = 0.8,
+		  noise_octaves_difference = -0.5,
+		},
+	  },
+	  order = "za",
+	  tile_restriction = { "sand-5" },
+	}
+	data.raw.tree["temperate-tree"].autoplace = {
+	  max_probability = 0.1,
+	  random_probability_penalty = 0.025,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  noise_layer = "temperate-tree-noise",
+		  noise_persistence = 0.8,
+		  noise_octaves_difference = -0.5,
+		},
+	  },
+	  order = "zc",
+	  tile_restriction = { "sand-5" },
+	}
+
+	data.raw.tree["swamp-tree"].autoplace = {
+	  max_probability = 0.05,
+	  peaks = {
+		{
+		  influence = 1,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(20),
+		  elevation_range = plant_elevation_range,
+		  elevation_max_range = plant_elevation_range,
+		},
+		{
+		  influence = 1,
+		  max_influence = 0,
+		  noise_layer = "swamp-tree-noise",
+		  noise_persistence = 0.8,
+		  noise_octaves_difference = -0.5,
+		},
+	  },
+	  order = "zb",
+	  tile_restriction = { "sand-5" },
+	}
+
+	data.raw.tile["water"].autoplace = {
+	  peaks = {
+		{
+		  influence = 0.1, -- shallow water around cliff islands
+		  min_influence = 0,
+		  elevation_optimal = -2 * elevation_scale + waterline,
+		  elevation_range = 2.5 * elevation_scale,
+		  elevation_max_range = 2.5 * elevation_scale,
+		},
+		{
+		  influence = 0.77 * 2, -- around worm islands
+		  min_influence = 0,
+		  max_influence = 1,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		},
+		{
+		  influence = 5, -- around starting tile
+		  min_influence = 0,
+		  distance_optimal = 0,
+		  distance_range = 5,
+		  distance_max_range = 5,
+		},
+	  },
+	}
+
+	data.raw.tile["deepwater"].autoplace = {
+	  peaks = {
+		{
+		  influence = 0.01,
+		},
+	  },
+	}
+
+	data.raw.fish["alien-fish-1"].autoplace = {
+	  peaks = {
+		{
+		  influence = -0.1,
+		  max_influence = 0,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		},
+		{
+		  influence = 0.01,
+		},
+	  },
+	}
+
+	data.raw.fish["alien-fish-2"].autoplace = {
+	  peaks = {
+		{
+		  influence = 0.02,
+		  min_influence = 0,
+		  noise_layer = "enemy-base",
+		  noise_octaves_difference = octaves,
+		  noise_persistence = persistence,
+		},
+	  },
+	}
+
+	data.raw.fish["alien-fish-3"].autoplace = {
+	  peaks = {
+		{
+		  influence = 0.015,
+		  min_influence = 0,
+		  elevation_optimal = scale_elevation(10),
+		  elevation_range = 5 * elevation_scale,
+		  elevation_max_range = 5 * elevation_scale,
+		  tier_from_start_optimal = 0.1,
+		  tier_from_start_range = 0,
+		  tier_from_start_max_range = 0,
+		  tier_from_start_top_property_limit = 0.1,
+		},
+	  },
+	}
+
+	local noise = require("noise")
+	local tne = noise.to_noise_expression
+	local enemy_random_seed = 1
+	local function new_random_seed()
+	  enemy_random_seed = enemy_random_seed + 1
+	  return enemy_random_seed
+	end
+	local function worm_autoplace(distance, probability, order, falloff, control_name)
+	  local d = noise.var("distance") - noise.var("starting_area_radius")
+	  local p = noise.clamp((d - distance * 128) / 128, 0, 1)
+	  if falloff then
+		p = p * noise.clamp(((distance + 2) * 128 - d) / 128, 0, 1)
+	  end
+	  p = p * noise.clamp((waterline - noise.var("elevation")), 0, 1)
+	  p = p * probability
+	  p = noise.random_penalty(p, probability * 0.5, {
+		x = noise.var("x") + new_random_seed(),
+	  })
+
+	  return {
+		control = control_name,
+		order = order,
+		force = "enemy",
+		probability_expression = p,
+		richness_expression = tne(1),
+	  }
+	end
+
+	data.raw.turret["small-worm-turret"].autoplace = worm_autoplace(0, 1, "z", true, "enemy-base")
+	data.raw.turret["medium-worm-turret"].autoplace = worm_autoplace(1, 1, "y", true, "enemy-base")
+	if data.raw.turret["bob-big-explosive-worm-turret"] then
+	  data.raw.turret["bob-big-explosive-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	end
+	if data.raw.turret["bob-big-fire-worm-turret"] then
+	  data.raw.turret["bob-big-fire-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	end
+	if data.raw.turret["bob-big-poison-worm-turret"] then
+	  data.raw.turret["bob-big-poison-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	end
+	if data.raw.turret["bob-big-piercing-worm-turret"] then
+	  data.raw.turret["bob-big-piercing-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	end
+	if data.raw.turret["bob-big-electric-worm-turret"] then
+	  data.raw.turret["bob-big-electric-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	end
+	if data.raw.turret["bob-giant-worm-turret"] then
+	  data.raw.turret["bob-giant-worm-turret"].autoplace = worm_autoplace(2, 0.6, "u", false, "enemy-base")
+	end
+	if data.raw.turret["behemoth-worm-turret"] then
+	  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
+	  data.raw.turret["behemoth-worm-turret"].autoplace = worm_autoplace(2, 0.2, "t", false, "enemy-base")
+	else
+	  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(2, 1, "v", false, "enemy-base")
+	end
+	data.raw.tree["puffer-nest"].autoplace = worm_autoplace(0, 0.01, "s", false)
+
+	for _, v in pairs(data.raw.turret) do
+	  v.map_generator_bounding_box = nil
+	end
+
+	data:extend({
+	  {
+		type = "noise-layer",
+		name = "desert-tree-noise",
+	  },
+	  {
+		type = "noise-layer",
+		name = "temperate-tree-noise",
+	  },
+	  {
+		type = "noise-layer",
+		name = "swamp-tree-noise",
+	  },
+	  {
+		type = "noise-layer",
+		name = "desert-garden-noise",
+	  },
+	  {
+		type = "noise-layer",
+		name = "temperate-garden-noise",
+	  },
+	  {
+		type = "noise-layer",
+		name = "swamp-garden-noise",
+	  },
+	})
+
+	local function make_basis_noise_function(seed0, seed1, outscale0, inscale0)
+	  outscale0 = outscale0 or 1
+	  inscale0 = inscale0 or 1 / outscale0
+	  return function(x, y, inscale, outscale)
+		return tne({
+		  type = "function-application",
+		  function_name = "factorio-basis-noise",
+		  arguments = {
+			x = tne(x),
+			y = tne(y),
+			seed0 = tne(seed0),
+			seed1 = tne(seed1),
+			input_scale = tne((inscale or 1) * inscale0),
+			output_scale = tne((outscale or 1) * outscale0),
+		  },
+		})
+	  end
+	end
+
+	data.raw["noise-expression"]["cliffiness"].expression = noise.define_noise_function(function(x, y, tile, map)
+	  local t = noise.clamp((tile.tier - 0.2) * noise.ceil(noise.var("control-setting:cliffs:richness:multiplier")), 0, 1) -- No cliffs in starting area
+	  return 100 * t
+	end)
+	data.raw["noise-expression"]["elevation"].expression = noise.define_noise_function(function(x, y, tile, map)
+	  x = x + 40000
+	  y = y
+	  local v = make_basis_noise_function(map.seed, 5, 6, 1 / 64)(x, y)
+	  v = noise.max(v, 0)
+	  v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
+	  return v
+	end)
 end
-
--- Want player to collide with cliffs
--- Want player to collide with water
--- Don't want cliffs to collide with water
--- Water tile's default collision mask includes player-layer and item-layer
--- So use train-layer as a substitute player-layer
-data.raw.cliff["cliff"].collision_mask = { "object-layer", "train-layer", "not-colliding-with-itself" }
-
-local octaves = -3
-local persistence = 0.2
-local waterline = 9.4
-local elevation_scale = 5
-local function scale_elevation(x)
-  return (x - waterline) * elevation_scale + waterline
-end
--- low lying sand
-data.raw.tile["sand-4"].autoplace = {
-  peaks = {
-    { -- Around cliff islands
-      influence = 5,
-      elevation_optimal = 0.3 * elevation_scale + waterline,
-      elevation_range = 0.3 * elevation_scale,
-      elevation_max_range = 0.3 * elevation_scale,
-    },
-    {
-      influence = 0.77 * 8, -- Worm islands
-      min_influence = 0,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-      tier_from_start_optimal = 8,
-      tier_from_start_max_range = 40,
-      tier_from_start_top_property_limit = 8,
-    },
-    { -- Not in starting area
-      influence = -5,
-      starting_area_weight_optimal = 1,
-      starting_area_weight_range = 0,
-      starting_area_weight_max_range = 0,
-    },
-    {
-      influence = 100, -- ... except for starting tile
-      min_influence = 0,
-      distance_optimal = 0,
-      distance_range = 0.1,
-      distance_max_range = 0.1,
-    },
-    {
-      influence = -5,
-    },
-  },
-}
-
--- highground sand
-data.raw.tile["sand-5"].autoplace = {
-  peaks = {
-    {
-      influence = 5,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(15),
-      elevation_range = 5 * elevation_scale,
-      elevation_max_range = 5 * elevation_scale,
-      tier_from_start_optimal = 0.1,
-      tier_from_start_range = 0,
-      tier_from_start_max_range = 0,
-      tier_from_start_top_property_limit = 0.1,
-    },
-    {
-      influence = 0.65, -- starting area garden islands
-      min_influence = 0,
-      max_influence = 1,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-      tier_from_start_optimal = 0,
-      tier_from_start_range = 0.1,
-      tier_from_start_max_range = 0.1,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      starting_area_weight_optimal = 1,
-      starting_area_weight_range = 0,
-      starting_area_weight_max_range = 0,
-    },
-    {
-      influence = -100, -- not on starting tile
-      max_influence = 0,
-      distance_optimal = 0,
-      distance_range = 3,
-      distance_max_range = 3,
-    },
-  },
-}
-
-local plant_elevation_range = 9.9 * elevation_scale
-data.raw.tree["desert-garden"].autoplace = {
-  max_probability = 0.2,
-  random_probability_penalty = 0.05,
-  sharpness = 1,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-    {
-      influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
-      min_influence = 0,
-      max_influence = 1,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-      tier_from_start_optimal = 0,
-      tier_from_start_range = 0.1,
-      tier_from_start_max_range = 0.1,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      noise_layer = "desert-garden-noise",
-      noise_persistence = 0.8,
-      noise_octaves_difference = -0.5,
-    },
-  },
-  order = "yc",
-  tile_restriction = { "sand-5" },
-}
-
-data.raw.tree["temperate-garden"].autoplace = {
-  max_probability = 0.2,
-  random_probability_penalty = 0.05,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      noise_layer = "temperate-garden-noise",
-      noise_persistence = 0.8,
-      noise_octaves_difference = -0.5,
-    },
-  },
-  order = "ya",
-  tile_restriction = { "sand-5" },
-}
-
-data.raw.tree["swamp-garden"].autoplace = {
-  max_probability = 0.05,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-  },
-  order = "yb",
-  tile_restriction = { "sand-5" },
-}
-
-data.raw.tree["desert-tree"].autoplace = {
-  max_probability = 0.1,
-  random_probability_penalty = 0.025,
-  sharpness = 1,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-    {
-      influence = 0.31, -- Trial and error value to generate size that approximately matches starting area islands
-      min_influence = 0,
-      max_influence = 1,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-      tier_from_start_optimal = 0,
-      tier_from_start_range = 0.1,
-      tier_from_start_max_range = 0.1,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      noise_layer = "desert-tree-noise",
-      noise_persistence = 0.8,
-      noise_octaves_difference = -0.5,
-    },
-  },
-  order = "za",
-  tile_restriction = { "sand-5" },
-}
-data.raw.tree["temperate-tree"].autoplace = {
-  max_probability = 0.1,
-  random_probability_penalty = 0.025,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      noise_layer = "temperate-tree-noise",
-      noise_persistence = 0.8,
-      noise_octaves_difference = -0.5,
-    },
-  },
-  order = "zc",
-  tile_restriction = { "sand-5" },
-}
-
-data.raw.tree["swamp-tree"].autoplace = {
-  max_probability = 0.05,
-  peaks = {
-    {
-      influence = 1,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(20),
-      elevation_range = plant_elevation_range,
-      elevation_max_range = plant_elevation_range,
-    },
-    {
-      influence = 1,
-      max_influence = 0,
-      noise_layer = "swamp-tree-noise",
-      noise_persistence = 0.8,
-      noise_octaves_difference = -0.5,
-    },
-  },
-  order = "zb",
-  tile_restriction = { "sand-5" },
-}
-
-data.raw.tile["water"].autoplace = {
-  peaks = {
-    {
-      influence = 0.1, -- shallow water around cliff islands
-      min_influence = 0,
-      elevation_optimal = -2 * elevation_scale + waterline,
-      elevation_range = 2.5 * elevation_scale,
-      elevation_max_range = 2.5 * elevation_scale,
-    },
-    {
-      influence = 0.77 * 2, -- around worm islands
-      min_influence = 0,
-      max_influence = 1,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-    },
-    {
-      influence = 5, -- around starting tile
-      min_influence = 0,
-      distance_optimal = 0,
-      distance_range = 5,
-      distance_max_range = 5,
-    },
-  },
-}
-
-data.raw.tile["deepwater"].autoplace = {
-  peaks = {
-    {
-      influence = 0.01,
-    },
-  },
-}
-
-data.raw.fish["alien-fish-1"].autoplace = {
-  peaks = {
-    {
-      influence = -0.1,
-      max_influence = 0,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-    },
-    {
-      influence = 0.01,
-    },
-  },
-}
-
-data.raw.fish["alien-fish-2"].autoplace = {
-  peaks = {
-    {
-      influence = 0.02,
-      min_influence = 0,
-      noise_layer = "enemy-base",
-      noise_octaves_difference = octaves,
-      noise_persistence = persistence,
-    },
-  },
-}
-
-data.raw.fish["alien-fish-3"].autoplace = {
-  peaks = {
-    {
-      influence = 0.015,
-      min_influence = 0,
-      elevation_optimal = scale_elevation(10),
-      elevation_range = 5 * elevation_scale,
-      elevation_max_range = 5 * elevation_scale,
-      tier_from_start_optimal = 0.1,
-      tier_from_start_range = 0,
-      tier_from_start_max_range = 0,
-      tier_from_start_top_property_limit = 0.1,
-    },
-  },
-}
-
-local noise = require("noise")
-local tne = noise.to_noise_expression
-local enemy_random_seed = 1
-local function new_random_seed()
-  enemy_random_seed = enemy_random_seed + 1
-  return enemy_random_seed
-end
-local function worm_autoplace(distance, probability, order, falloff, control_name)
-  local d = noise.var("distance") - noise.var("starting_area_radius")
-  local p = noise.clamp((d - distance * 128) / 128, 0, 1)
-  if falloff then
-    p = p * noise.clamp(((distance + 2) * 128 - d) / 128, 0, 1)
-  end
-  p = p * noise.clamp((waterline - noise.var("elevation")), 0, 1)
-  p = p * probability
-  p = noise.random_penalty(p, probability * 0.5, {
-    x = noise.var("x") + new_random_seed(),
-  })
-
-  return {
-    control = control_name,
-    order = order,
-    force = "enemy",
-    probability_expression = p,
-    richness_expression = tne(1),
-  }
-end
-
-data.raw.turret["small-worm-turret"].autoplace = worm_autoplace(0, 1, "z", true, "enemy-base")
-data.raw.turret["medium-worm-turret"].autoplace = worm_autoplace(1, 1, "y", true, "enemy-base")
-if data.raw.turret["bob-big-explosive-worm-turret"] then
-  data.raw.turret["bob-big-explosive-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-end
-if data.raw.turret["bob-big-fire-worm-turret"] then
-  data.raw.turret["bob-big-fire-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-end
-if data.raw.turret["bob-big-poison-worm-turret"] then
-  data.raw.turret["bob-big-poison-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-end
-if data.raw.turret["bob-big-piercing-worm-turret"] then
-  data.raw.turret["bob-big-piercing-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-end
-if data.raw.turret["bob-big-electric-worm-turret"] then
-  data.raw.turret["bob-big-electric-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-end
-if data.raw.turret["bob-giant-worm-turret"] then
-  data.raw.turret["bob-giant-worm-turret"].autoplace = worm_autoplace(2, 0.6, "u", false, "enemy-base")
-end
-if data.raw.turret["behemoth-worm-turret"] then
-  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(1.5, 0.5, "v", false, "enemy-base")
-  data.raw.turret["behemoth-worm-turret"].autoplace = worm_autoplace(2, 0.2, "t", false, "enemy-base")
-else
-  data.raw.turret["big-worm-turret"].autoplace = worm_autoplace(2, 1, "v", false, "enemy-base")
-end
-data.raw.tree["puffer-nest"].autoplace = worm_autoplace(0, 0.01, "s", false)
-
-for _, v in pairs(data.raw.turret) do
-  v.map_generator_bounding_box = nil
-end
-
-data:extend({
-  {
-    type = "noise-layer",
-    name = "desert-tree-noise",
-  },
-  {
-    type = "noise-layer",
-    name = "temperate-tree-noise",
-  },
-  {
-    type = "noise-layer",
-    name = "swamp-tree-noise",
-  },
-  {
-    type = "noise-layer",
-    name = "desert-garden-noise",
-  },
-  {
-    type = "noise-layer",
-    name = "temperate-garden-noise",
-  },
-  {
-    type = "noise-layer",
-    name = "swamp-garden-noise",
-  },
-})
-
-local function make_basis_noise_function(seed0, seed1, outscale0, inscale0)
-  outscale0 = outscale0 or 1
-  inscale0 = inscale0 or 1 / outscale0
-  return function(x, y, inscale, outscale)
-    return tne({
-      type = "function-application",
-      function_name = "factorio-basis-noise",
-      arguments = {
-        x = tne(x),
-        y = tne(y),
-        seed0 = tne(seed0),
-        seed1 = tne(seed1),
-        input_scale = tne((inscale or 1) * inscale0),
-        output_scale = tne((outscale or 1) * outscale0),
-      },
-    })
-  end
-end
-
-data.raw["noise-expression"]["cliffiness"].expression = noise.define_noise_function(function(x, y, tile, map)
-  local t = noise.clamp((tile.tier - 0.2) * noise.ceil(noise.var("control-setting:cliffs:richness:multiplier")), 0, 1) -- No cliffs in starting area
-  return 100 * t
-end)
-data.raw["noise-expression"]["elevation"].expression = noise.define_noise_function(function(x, y, tile, map)
-  x = x + 40000
-  y = y
-  local v = make_basis_noise_function(map.seed, 5, 6, 1 / 64)(x, y)
-  v = noise.max(v, 0)
-  v = (v * elevation_scale) - (waterline * (elevation_scale - 1)) -- Increase gradient for cliffs while leaving waterline unchanged
-  return v
-end)

--- a/SeaBlock/settings.lua
+++ b/SeaBlock/settings.lua
@@ -30,4 +30,20 @@ data:extend({
     }
 })
 
-      
+data:extend({
+    {
+      type = "bool-setting",
+      name = "No-minerals-mode-setting",
+      setting_type = "startup",
+      default_value = true
+    }
+})
+
+data:extend({
+    {
+      type = "bool-setting",
+      name = "No-trees-mode-setting",
+      setting_type = "startup",
+      default_value = true
+    }
+})

--- a/SeaBlock/settings.lua
+++ b/SeaBlock/settings.lua
@@ -20,3 +20,14 @@ if mods["LandfillPainting"] then
     },
   })
 end
+
+data:extend({
+    {
+      type = "bool-setting",
+      name = "Landblock-mode-Seablock-setting",
+      setting_type = "startup",
+      default_value = false
+    }
+})
+
+      


### PR DESCRIPTION
Added three settings named Landblock mode, no minerals mode, and no trees setting. 
The Landblock setting (default off) sets the map generation to normal for tiles and spawners, but does not affect resources, or trees/rocks. 
The no minerals mode (default on) makes it so that ores don't generate, this is added for mod compatibility (looking at you Modmash Underground).
The no trees setting (default on) makes it so that both normal trees and rocks don't spawn. I put this in to complete the set/aesthetic reasons.

All three are startup settings, and have been localized for English. 

Also for the Landblock mode to recover normal biter activity the Angel-biter-slider setting has to bet set to 600%. This is not the default behavior and I don't know how to change it. 