### PR TITLE
Fix #315 (Disabled "steam-inserter" breaking AAI Loaders)

### DIFF
--- a/SeaBlock/changelog.txt
+++ b/SeaBlock/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.5.15
 Date: ???
   Bugfixes:
     - Fixed Landfill tech being automatically researched #312
+    - Fixed AAI Loaders compatibility #315
 ---------------------------------------------------------------------------------------------------
 Version: 0.5.14
 Date: 22.12.2023

--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -105,7 +105,6 @@ bobmods.lib.tech.remove_prerequisite("tungsten-processing", "angels-nickel-smelt
 
 bobmods.lib.tech.remove_recipe_unlock("bio-arboretum-swamp-1", "solid-plastic")
 
-seablock.lib.hide("inserter", "steam-inserter")
 seablock.lib.hide("mining-drill", "burner-mining-drill")
 seablock.lib.hide("mining-drill", "electric-mining-drill")
 seablock.lib.hide("mining-drill", "pumpjack")
@@ -276,10 +275,12 @@ bobmods.lib.recipe.set_energy_required("copper-tungsten-alloy", 8)
 bobmods.lib.tech.add_prerequisite("tungsten-alloy-processing", "angels-copper-smelting-2")
 
 -- Hide steam inserter
+seablock.lib.hide("inserter", "steam-inserter")
 bobmods.lib.recipe.hide("steam-inserter")
 seablock.lib.hide_item("steam-inserter")
 if data.raw.inserter["steam-inserter"] then
   data.raw.inserter["steam-inserter"].next_upgrade = nil
+  bobmods.lib.recipe.replace_ingredient_in_all("steam-inserter", "burner-inserter")
 end
 
 -- Swap out concrete for bricks


### PR DESCRIPTION
See #315. 

This replaces the "steam-inserter" ingredient with "burner-inserter" so that recipe's that depend on it don't break.